### PR TITLE
Add Cobertura

### DIFF
--- a/Code/pom.xml
+++ b/Code/pom.xml
@@ -93,8 +93,8 @@
             <ignores>
             </ignores>
             <excludes>
-              <exclude>com/example/dullcode/**/*.class</exclude>
-              <exclude>com/example/**/*Test.class</exclude>
+              <exclude>nl/utwente/group10/haskell/typeparser/*.class</exclude>
+              <exclude>nl/utwente/**/*Test.class</exclude>
             </excludes>
           </instrumentation>
           <check>


### PR DESCRIPTION
This pull requests adds the Cobertura plugin to pom.xml, which means we can now run code coverage checking on the codebase. Doing `mvn cobertura:cobertura` in the code directory should generate a nice report, in both user-friendly HTML and tool-friendly XML formats, in the `target/site` directory.
