### PR TITLE
Close GHCI sessions in tests

### DIFF
--- a/Code/src/test/java/nl/utwente/group10/ghcj/GhciEnvironmentTest.java
+++ b/Code/src/test/java/nl/utwente/group10/ghcj/GhciEnvironmentTest.java
@@ -5,8 +5,10 @@ import org.junit.Test;
 
 public class GhciEnvironmentTest {
     @Test
-    public void putStrLnTest() throws GhciException {
-        GhciEnvironment env = new GhciSession().getEnvironment();
+    public void putStrLnTest() throws Exception {
+        GhciSession session = new GhciSession();
+        GhciEnvironment env = session.getEnvironment();
         Assert.assertTrue(!env.getBindings().isEmpty());
+        session.close();
     }
 }

--- a/Code/src/test/java/nl/utwente/group10/ghcj/GhciSanityTest.java
+++ b/Code/src/test/java/nl/utwente/group10/ghcj/GhciSanityTest.java
@@ -1,13 +1,21 @@
 package nl.utwente.group10.ghcj;
 
 import org.junit.Assert;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 public class GhciSanityTest {
-    private final GhciSession ghci;
+    private GhciSession ghci;
 
-    public GhciSanityTest() throws GhciException {
+    @Before
+    public void startGhci() throws GhciException {
         this.ghci = new GhciSession();
+    }
+
+    @After
+    public void stopGhci() throws Exception {
+        this.ghci.close();
     }
 
     @Test


### PR DESCRIPTION
This prevents GhciSession objects from hanging around when they're no longer needed.
