### PR TITLE
Add Eclipse-specific stuff to gitignore

### DIFF
--- a/Code/.gitignore
+++ b/Code/.gitignore
@@ -1,10 +1,18 @@
+# Maven
 target/
 pom.xml.tag
 pom.xml.releaseBackup
 pom.xml.versionsBackup
 pom.xml.next
 release.properties
+
+# IDEA
 *.iml
 *.ipr
 *.iws
 .idea
+
+# Eclipse
+.classpath
+.project
+.settings


### PR DESCRIPTION
This PR adds project files Eclipse generates to .gitignore, preventing them
from being added to the repository.
