### PR TITLE
Remove superfluous keywords from some interfaces

### DIFF
--- a/Code/src/main/java/nl/utwente/viskell/ui/BlockContainer.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/BlockContainer.java
@@ -13,30 +13,30 @@ import nl.utwente.viskell.ui.components.Block;
 public interface BlockContainer {
 
     /** Gets the bounds to be used for testing what is inside this container, transformed into the coordinate space of its scene. */
-    public Bounds containmentBoundsInScene();
+    Bounds containmentBoundsInScene();
     
     /** Attach a block to this container */
-    public void attachBlock(Block block);
+    void attachBlock(Block block);
     
     /** Detach a block from this container */
-    public void detachBlock(Block block);
+    void detachBlock(Block block);
 
     /** @return a stream of all block attached to this container */
-    public Stream<Block> getAttachedBlocks();
+    Stream<Block> getAttachedBlocks();
     
     /** Check whether this container contains the specified block */
-    public default boolean containsBlock(Block block) {
+    default boolean containsBlock(Block block) {
         return this.getAttachedBlocks().anyMatch(a -> block.equals(a));
     }
     
     /** @return the container to which this container belongs, maybe return itself if it is the outermost container */
-    public BlockContainer getParentContainer();
+    BlockContainer getParentContainer();
 
     /**
      * @return the ToplevelPane where this container is (indirectly) part of. 
      * @throws IllegalStateException
      */
-    public default ToplevelPane getToplevel() {
+    default ToplevelPane getToplevel() {
         BlockContainer cont = this;
         while (cont.getParentContainer() != cont) {
             cont = cont.getParentContainer();
@@ -49,10 +49,10 @@ public interface BlockContainer {
         throw new IllegalStateException("Manipulating container that is not in a ToplevelPane");
     }
     
-    public abstract Node asNode();
+    Node asNode();
     
     /** @return Whether this container is (indirectly) contained with the other container. */
-    public default boolean isContainedWithin(BlockContainer other) {
+    default boolean isContainedWithin(BlockContainer other) {
         if (this == other) {
             return true;
         }
@@ -72,10 +72,10 @@ public interface BlockContainer {
      * Grows the bounds of this container to fit the given additional bounds.
      * @param blockBounds of the Block that needs to fit in the container.
      */
-    public void expandToFit(Bounds blockBounds);
+    void expandToFit(Bounds blockBounds);
     
     /** Return the union of two Bounds, i.e. a Bound that contains both. */
-    public static Bounds union(Bounds a, Bounds b) {
+    static Bounds union(Bounds a, Bounds b) {
         double left   = Math.min(a.getMinX(), b.getMinX());
         double right  = Math.max(a.getMaxX(), b.getMaxX());
         double top    = Math.min(a.getMinY(), b.getMinY());

--- a/Code/src/main/java/nl/utwente/viskell/ui/components/ConnectionAnchor.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/components/ConnectionAnchor.java
@@ -18,9 +18,9 @@ import nl.utwente.viskell.ui.serialize.Bundleable;
 public abstract class ConnectionAnchor extends StackPane implements ComponentLoader, Bundleable {
 
     /** Helper interface for finding the associated connection anchor on release a wire onto something. */
-    public static interface Target {
+    public interface Target {
         /** @return the connection anchor directly related to the Target object. */
-        public ConnectionAnchor getAssociatedAnchor();
+        ConnectionAnchor getAssociatedAnchor();
     }
     
     /** The connection being drawn starting from this anchor, or null if none. */

--- a/Code/src/main/java/nl/utwente/viskell/ui/components/FunctionReference.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/components/FunctionReference.java
@@ -10,26 +10,26 @@ import nl.utwente.viskell.ui.BlockContainer;
 
 public interface FunctionReference {
     
-    public void initializeBlock(Block funBlock);
+    void initializeBlock(Block funBlock);
     
-    public Optional<InputAnchor> getInputAnchor();
+    Optional<InputAnchor> getInputAnchor();
     
-    public int requiredArguments();
+    int requiredArguments();
     
-    public Type refreshedType(int argCount, TypeScope scope);
+    Type refreshedType(int argCount, TypeScope scope);
     
-    public Expression getLocalExpr(Set<OutputAnchor> outsideAnchors);
+    Expression getLocalExpr(Set<OutputAnchor> outsideAnchors);
 
-    public void invalidateVisualState();
+    void invalidateVisualState();
     
-    public Region asRegion();
+    Region asRegion();
     
-    public FunctionReference getNewCopy();
+    FunctionReference getNewCopy();
     
-    public String getName();
+    String getName();
     
-    public boolean isScopeCorrectIn(BlockContainer container);
+    boolean isScopeCorrectIn(BlockContainer container);
 
-    public void deleteLinks();
+    void deleteLinks();
 
 }

--- a/Code/src/main/java/nl/utwente/viskell/ui/components/WrappedContainer.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/components/WrappedContainer.java
@@ -8,22 +8,22 @@ import nl.utwente.viskell.ui.ToplevelPane;
 public interface WrappedContainer extends BlockContainer {
 
     /** Get the block wrapping this container. */
-    public Block getWrapper();
+    Block getWrapper();
     
     @Override
-    public default ToplevelPane getToplevel() {
+    default ToplevelPane getToplevel() {
         return this.getWrapper().getToplevel();
     }
     
     /** Set fresh types in all anchors of this lambda for the next typechecking cycle. */
-    public void refreshAnchorTypes();
+    void refreshAnchorTypes();
 
     /**
      * Handle the expression and types changes caused by modified connections or values.
      * Also propagate the changes through internal connected blocks, and then outwards.
      * @param finalPhase whether the change propagation is in the second (final) phase.
      */
-    public void handleConnectionChanges(boolean finalPhase);
+    void handleConnectionChanges(boolean finalPhase);
 
     /** Move the attached blocks with the specified offset */
     default void moveNodes(double dx, double dy) {
@@ -35,6 +35,6 @@ public interface WrappedContainer extends BlockContainer {
     }
     
     /** Delete all associations of this container with others in preparation of deletion, including all connections */
-    public void deleteAllLinks();
+    void deleteAllLinks();
     
 }


### PR DESCRIPTION
Methods in an interface are always public, so the `public` keyword is
unnecessary.