### PR TITLE
Use a TopMenu on Mac OS X instead of onscreen context menu for touch devices.

### DIFF
--- a/Code/src/main/java/nl/utwente/viskell/ui/GlobalContextMenu.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/GlobalContextMenu.java
@@ -1,0 +1,28 @@
+package nl.utwente.viskell.ui;
+
+import javafx.scene.control.ContextMenu;
+import javafx.scene.control.MenuItem;
+
+/**
+ * A context menu with global actions (i.e. quit).
+ */
+public class GlobalContextMenu extends ContextMenu {
+    public GlobalContextMenu(MenuActions menuActions) {
+        super();
+
+        MenuItem menuPreferences = new MenuItem("Preferences...");
+        menuPreferences.setOnAction(menuActions::showPreferences);
+
+        MenuItem menuInspector = new MenuItem("Inspector");
+        menuInspector.setOnAction(menuActions::showInspector);
+
+        MenuItem menuFullScreen = new MenuItem("Toggle full screen");
+        menuFullScreen.setOnAction(menuActions::toggleFullScreen);
+        
+        MenuItem menuQuit = new MenuItem("Quit");
+        menuQuit.setOnAction(menuActions::onQuit);
+
+        this.getItems().addAll(menuActions.fileMenuItems());
+        this.getItems().addAll(menuInspector, menuPreferences, menuFullScreen, menuQuit);
+    }
+}

--- a/Code/src/main/java/nl/utwente/viskell/ui/MacTopMenu.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/MacTopMenu.java
@@ -1,0 +1,41 @@
+package nl.utwente.viskell.ui;
+
+import javafx.scene.control.Menu;
+import javafx.scene.control.MenuBar;
+import javafx.scene.control.MenuItem;
+
+/**
+ * A top menu bar with global actions
+ */
+public class MacTopMenu extends MenuBar {
+    public MacTopMenu(MenuActions menuActions) {
+        super();
+
+        useSystemMenuBarProperty().set(true);
+
+        // Viskell menu items on mac - preferences and quit
+        MenuItem preferencesMenuItem = new MenuItem("Preferences");
+        preferencesMenuItem.setOnAction(menuActions::showPreferences);
+
+        MenuItem quitMenuItem = new MenuItem("Quit");
+        quitMenuItem.setOnAction(menuActions::onQuit);
+
+        final Menu appMenu = new Menu("Viskell");
+        appMenu.getItems().addAll(preferencesMenuItem, quitMenuItem);
+
+        // File menu
+        final Menu fileMenu = new Menu("File");
+        fileMenu.getItems().addAll(menuActions.fileMenuItems());
+
+        // View menu
+        final Menu viewMenu = new Menu("View");
+        MenuItem menuInspector = new MenuItem("Inspector");
+        menuInspector.setOnAction(menuActions::showInspector);
+        viewMenu.getItems().addAll(menuInspector);
+
+        // Help Menu
+        final Menu helpMenu = new Menu("Help");
+
+        getMenus().addAll(appMenu, fileMenu, viewMenu, helpMenu);
+    }
+}

--- a/Code/src/main/java/nl/utwente/viskell/ui/Main.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/Main.java
@@ -1,11 +1,8 @@
 package nl.utwente.viskell.ui;
 
-import java.util.prefs.Preferences;
-
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Scene;
@@ -15,15 +12,14 @@ import javafx.stage.Stage;
 import nl.utwente.viskell.ghcj.GhciSession;
 import nl.utwente.viskell.ghcj.HaskellException;
 
+import java.util.prefs.Preferences;
+
 /**
  * Main application class for the GUI.
  */
 public class Main extends Application {
     /** A reference to the main window */
     public static Stage primaryStage;
-
-    /** A reference to the overlay */
-    public static MainOverlay overlay;
 
     @Override
     public void start(Stage stage) throws Exception {
@@ -36,20 +32,14 @@ public class Main extends Application {
         
         // Init TactilePane
         ToplevelPane tactilePane = new ToplevelPane(ghci);
-
-        overlay = new MainOverlay(tactilePane);
-
-        // Init scene
+        MainOverlay overlay = new MainOverlay(tactilePane);
         Scene scene = new Scene(overlay);
-
         Preferences prefs = Preferences.userNodeForPackage(Main.class);
         String backGroundImage = prefs.get("background", "/ui/grid.png");
         overlay.getMainPane().setStyle("-fx-background-image: url('" + backGroundImage + "');");
         String theme = prefs.get("theme", "/ui/colours.css");
         scene.getStylesheets().addAll("/ui/layout.css", theme);
 
-        System.out.println(overlay.getStyle());
-        
         stage.setWidth(1024);
         stage.setHeight(768);
 
@@ -86,7 +76,6 @@ public class Main extends Application {
 
             e.printStackTrace(); // In case it's not a file-not-found
         }
-
     }
 
     /**

--- a/Code/src/main/java/nl/utwente/viskell/ui/MenuActions.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/MenuActions.java
@@ -1,0 +1,128 @@
+package nl.utwente.viskell.ui;
+
+import com.google.common.base.Charsets;
+import javafx.application.Platform;
+import javafx.event.ActionEvent;
+import javafx.scene.control.MenuItem;
+import javafx.stage.FileChooser;
+import javafx.stage.Stage;
+import javafx.stage.Window;
+import nl.utwente.viskell.ui.components.Block;
+import nl.utwente.viskell.ui.serialize.Exporter;
+import nl.utwente.viskell.ui.serialize.Importer;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * menu actions
+ */
+public class MenuActions {
+    /** The main overlay of which this menu is a part */ 
+    protected MainOverlay overlay;
+
+    /** The File we're currently working on, if any. */
+    private Optional<File> currentFile;
+
+    public MenuActions(MainOverlay overlay) {
+        this.overlay = overlay;
+        this.currentFile = Optional.empty();
+    }
+
+    protected List<MenuItem> fileMenuItems() {
+        List<MenuItem> list = new ArrayList<>();
+
+        MenuItem menuNew = new MenuItem("New");
+        menuNew.setOnAction(this::onNew);
+        list.add(menuNew);
+
+        MenuItem menuOpen = new MenuItem("Open...");
+        menuOpen.setOnAction(this::onOpen);
+        list.add(menuOpen);
+
+        MenuItem menuSave = new MenuItem("Save");
+        menuSave.setOnAction(this::onSave);
+        list.add(menuSave);
+
+        MenuItem menuSaveAs = new MenuItem("Save as...");
+        menuSaveAs.setOnAction(this::onSaveAs);
+        list.add(menuSaveAs);
+
+        return list;
+    }
+
+    @SuppressWarnings("UnusedParameters")
+    protected void showPreferences(ActionEvent actionEvent) {
+        this.overlay.showPreferences();
+    }
+
+    @SuppressWarnings("UnusedParameters")
+    protected void showInspector(ActionEvent actionEvent) {
+        this.overlay.showInspector();
+    }
+
+    protected void onNew(ActionEvent actionEvent) {
+        this.overlay.getMainPane().clearChildren();
+    }
+
+    protected void onOpen(ActionEvent actionEvent) {
+        Window window = this.overlay.getScene().getWindow();
+        File file = new FileChooser().showOpenDialog(window);
+
+        if (file != null) {
+            addChildrenFrom(file, this.overlay.getMainPane());
+        }
+    }
+
+    protected void onSave(ActionEvent actionEvent) {
+        if (this.currentFile.isPresent()) {
+            saveTo(this.currentFile.get());
+        } else {
+            onSaveAs(actionEvent);
+        }
+    }
+
+    protected void onSaveAs(ActionEvent actionEvent) {
+        Window window = this.overlay.getScene().getWindow();
+        File file = new FileChooser().showSaveDialog(window);
+
+        if (file != null) {
+            saveTo(file);
+            this.currentFile = Optional.of(file);
+        }
+    }
+
+    protected void addChildrenFrom(File file, ToplevelPane pane) {
+    }
+
+    protected void saveTo(File file) {
+        try (FileOutputStream fos = new FileOutputStream(file)) {
+            fos.write(Exporter.export(this.overlay.getMainPane()).getBytes(Charsets.UTF_8));
+            fos.close();
+        } catch (IOException e) {
+            // TODO do something sensible here
+            e.printStackTrace();
+        }
+    }
+    
+    @SuppressWarnings("UnusedParameters")
+    protected void toggleFullScreen(ActionEvent actionEvent) {
+        Stage stage = Main.primaryStage;
+        if (stage.isFullScreen()) {
+            stage.setFullScreen(false);
+        } else {
+            stage.setMaximized(true);
+            stage.setFullScreen(true);
+        }
+    }
+
+    @SuppressWarnings("UnusedParameters")
+    protected void onQuit(ActionEvent actionEvent) {
+        Platform.exit();
+    }
+}

--- a/Code/src/main/java/nl/utwente/viskell/ui/PreferencesWindow.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/PreferencesWindow.java
@@ -50,21 +50,21 @@ public class PreferencesWindow extends BorderPane implements ComponentLoader {
         background.getSelectionModel().select(preferences.get("background", "/ui/grid.png"));
         background.valueProperty().addListener(event -> {
             preferences.put("background", background.getValue());
-            refreshTheme();
+            refreshTheme(overlay);
         });
         
         theme.getItems().setAll(ImmutableList.of("/ui/colours.css", "/ui/debugColours.css"));
         theme.getSelectionModel().select(preferences.get("theme", "/ui/colours.css"));
         theme.valueProperty().addListener(event -> {
             preferences.put("theme", theme.getValue());
-            refreshTheme();
+            refreshTheme(overlay);
         });
         
         debugOverlay.setOnAction(event -> {
-            Main.overlay.setTouchVisible(debugOverlay.isSelected());
+            overlay.setTouchVisible(debugOverlay.isSelected());
         });
         
-        reloadTheme.setOnAction(event -> refreshTheme());
+        reloadTheme.setOnAction(event -> refreshTheme(overlay));
         
         stage.focusedProperty().addListener(new ChangeListener<Boolean>() {
             public void changed(ObservableValue<? extends Boolean> observable, Boolean old, Boolean newVal) {
@@ -74,16 +74,16 @@ public class PreferencesWindow extends BorderPane implements ComponentLoader {
             }
         });
 
-        refreshTheme();
+        refreshTheme(overlay);
     }
 
-    protected void refreshTheme() {
+    protected void refreshTheme(MainOverlay overlay) {
         Main.primaryStage.getScene().getStylesheets().clear();
         Main.primaryStage.getScene().getStylesheets().addAll("/ui/layout.css", preferences.get("theme", "/ui/colours.css"));
         stage.getScene().getStylesheets().clear();
         stage.getScene().getStylesheets().addAll("/ui/layout.css", preferences.get("theme", "/ui/colours.css"));
         String backGroundImage = preferences.get("background", "/ui/grid.png");
-        Main.overlay.getMainPane().setStyle("-fx-background-image: url('" + backGroundImage + "');");
+        overlay.getMainPane().setStyle("-fx-background-image: url('" + backGroundImage + "');");
     }
 
     public void show() {


### PR DESCRIPTION
Added MacTopMenu to create a Top application menu for Mac.
GlobalMenu refactored into GlobalContextMenu that is used for on-screen context menu, and MenuActions which are shared between all menus.
MainOverlay now wraps overlay in a BorderPane that accepts a TopMenu, and when detected we are running on a Mac it replaces the on-screen
context menu with a TopMenu that does the same actions (except full-screen which is a window control in Mac OS X).

Avoid referencing overlay via Main.java public overflow, use the parameter passed in to the constructor and pass down to refreshTheme()
MainOverlay doesn't need to be public in Main.java any more.