### PR TITLE
Add keyboard shortcuts to most menu items

### DIFF
--- a/Code/src/main/java/nl/utwente/viskell/ui/MacTopMenu.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/MacTopMenu.java
@@ -3,6 +3,9 @@ package nl.utwente.viskell.ui;
 import javafx.scene.control.Menu;
 import javafx.scene.control.MenuBar;
 import javafx.scene.control.MenuItem;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCodeCombination;
+import javafx.scene.input.KeyCombination;
 
 /**
  * A top menu bar with global actions
@@ -14,27 +17,47 @@ public class MacTopMenu extends MenuBar {
         useSystemMenuBarProperty().set(true);
 
         // Viskell menu items on mac - preferences and quit
+        final Menu appMenu = new Menu("Viskell");
         MenuItem preferencesMenuItem = new MenuItem("Preferences");
+        preferencesMenuItem.setAccelerator(new KeyCodeCombination(KeyCode.COMMA, KeyCombination.SHORTCUT_DOWN));
         preferencesMenuItem.setOnAction(menuActions::showPreferences);
 
         MenuItem quitMenuItem = new MenuItem("Quit");
+        quitMenuItem.setAccelerator(new KeyCodeCombination(KeyCode.Q, KeyCombination.SHORTCUT_DOWN));
         quitMenuItem.setOnAction(menuActions::onQuit);
-
-        final Menu appMenu = new Menu("Viskell");
         appMenu.getItems().addAll(preferencesMenuItem, quitMenuItem);
 
         // File menu
-        final Menu fileMenu = new Menu("File");
+        final Menu fileMenu = new Menu("_File");
+        fileMenu.setMnemonicParsing(true);
         fileMenu.getItems().addAll(menuActions.fileMenuItems());
 
         // View menu
-        final Menu viewMenu = new Menu("View");
+        final Menu viewMenu = new Menu("_View");
+        viewMenu.setMnemonicParsing(true);
+
         MenuItem menuInspector = new MenuItem("Inspector");
+        menuInspector.setAccelerator(new KeyCodeCombination(KeyCode.I, KeyCombination.SHORTCUT_DOWN));
         menuInspector.setOnAction(menuActions::showInspector);
-        viewMenu.getItems().addAll(menuInspector);
+
+        MenuItem fullscreen = new MenuItem("Toggle Fullscreen");
+        fullscreen.setAccelerator(new KeyCodeCombination(KeyCode.F, KeyCombination.SHORTCUT_DOWN));
+        fullscreen.setOnAction(menuActions::toggleFullScreen);
+
+        MenuItem zoomIn = new MenuItem("Zoom In");
+        zoomIn.setAccelerator(new KeyCodeCombination(KeyCode.PLUS, KeyCombination.SHORTCUT_DOWN));
+        zoomIn.setOnAction(menuActions::zoomIn);
+
+        // FIXME The shortcut inexplicably doesn't work on a Mac!
+        MenuItem zoomOut = new MenuItem("Zoom Out");
+        zoomOut.setAccelerator(new KeyCodeCombination(KeyCode.MINUS, KeyCombination.SHORTCUT_DOWN));
+        zoomOut.setOnAction(menuActions::zoomOut);
+
+        viewMenu.getItems().addAll(menuInspector, fullscreen, zoomIn, zoomOut);
 
         // Help Menu
-        final Menu helpMenu = new Menu("Help");
+        final Menu helpMenu = new Menu("_Help");
+        helpMenu.setMnemonicParsing(true);
 
         getMenus().addAll(appMenu, fileMenu, viewMenu, helpMenu);
     }

--- a/Code/src/main/java/nl/utwente/viskell/ui/MainOverlay.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/MainOverlay.java
@@ -25,12 +25,6 @@ public class MainOverlay extends BorderPane {
     private final Pane touchOverlay;
     final Map<Integer, TouchDisplay> circleByTouchId;
 
-    /** The current preferences window, or null if not yet opened. */
-    private PreferencesWindow preferences;
-
-    /** The current inspector window, or null if not yet opened. */
-    private InspectorWindow inspector;
-
     private final ToplevelPane toplevelPane;
     
     public MainOverlay(ToplevelPane toplevelPane) {
@@ -75,10 +69,11 @@ public class MainOverlay extends BorderPane {
         });
 
         StackPane stack = new StackPane();
+        MenuActions menuActions = new MenuActions(this);
 
         final String os = System.getProperty("os.name");
         boolean topMenu = (os != null && os.startsWith ("Mac"));
-        stack.getChildren().setAll(this.toplevelPane, makeZoomBar(), makeToolBars(topMenu), touchOverlay);
+        stack.getChildren().setAll(this.toplevelPane, makeZoomBar(menuActions), makeToolBars(topMenu, menuActions), touchOverlay);
         this.setCenter(stack);
     }
 
@@ -86,9 +81,8 @@ public class MainOverlay extends BorderPane {
         return this.toplevelPane;
     }
 
-    private FlowPane makeToolBars(boolean topMenu) {
+    private FlowPane makeToolBars(boolean topMenu, MenuActions menuActions) {
         FlowPane toolBar;
-        MenuActions menuActions = new MenuActions(this);
 
         if (topMenu) {
             setTop(new MacTopMenu(menuActions));
@@ -112,12 +106,12 @@ public class MainOverlay extends BorderPane {
         return toolBar;
     }
 
-    private FlowPane makeZoomBar() {
+    private FlowPane makeZoomBar(MenuActions menuActions) {
         Button zoomIn = new Button("+");
-        zoomIn.setOnAction(e -> this.zoom(1.1));
+        zoomIn.setOnAction(menuActions::zoomIn);
 
         Button zoomOut = new Button("–");
-        zoomOut.setOnAction(e -> this.zoom(1/1.1));
+        zoomOut.setOnAction(menuActions::zoomOut);
 
         FlowPane zoomBar = new FlowPane(10, 0, zoomIn, zoomOut);
         zoomBar.setPrefSize(100, 20);
@@ -131,38 +125,4 @@ public class MainOverlay extends BorderPane {
     public void setTouchVisible(boolean value) {
         this.touchOverlay.setVisible(value);
     }
-
-    public void showPreferences() {
-        if (this.preferences == null) {
-            this.preferences = new PreferencesWindow(this);
-        }
-
-        this.preferences.show();
-    }
-
-    public void showInspector() {
-        if (this.inspector == null) {
-            this.inspector = new InspectorWindow(this);
-        }
-
-        this.inspector.show();
-    }
-
-    /**
-     * Zooms the underlying main pane in/out with a ratio, up to reasonable limits. 
-     * @param ratio the additional zoom factor to apply.
-     */
-    private void zoom(double ratio) {
-        double scale = this.toplevelPane.getScaleX();
-
-        /* Limit zoom to reasonable range. */
-        if (scale <= 0.2 && ratio < 1) return;
-        if (scale >= 3 && ratio > 1) return;
-
-        this.toplevelPane.setScaleX(scale * ratio);
-        this.toplevelPane.setScaleY(scale * ratio);
-        this.toplevelPane.setTranslateX(this.toplevelPane.getTranslateX() * ratio);
-        this.toplevelPane.setTranslateY(this.toplevelPane.getTranslateY() * ratio);
-    }
-
 }

--- a/Code/src/main/java/nl/utwente/viskell/ui/MenuActions.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/MenuActions.java
@@ -4,6 +4,9 @@ import com.google.common.base.Charsets;
 import javafx.application.Platform;
 import javafx.event.ActionEvent;
 import javafx.scene.control.MenuItem;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCodeCombination;
+import javafx.scene.input.KeyCombination;
 import javafx.stage.FileChooser;
 import javafx.stage.Stage;
 import javafx.stage.Window;
@@ -21,14 +24,24 @@ import java.util.*;
  * menu actions
  */
 public class MenuActions {
-    /** The main overlay of which this menu is a part */ 
+    /**
+     * The main overlay of which this menu is a part
+     */
     protected MainOverlay overlay;
 
-    /** The File we're currently working on, if any. */
+    /**
+     * The File we're currently working on, if any.
+     */
     private Optional<File> currentFile;
 
-    public MenuActions(MainOverlay overlay) {
-        this.overlay = overlay;
+    /** The current preferences window, or null if not yet opened. */
+    private PreferencesWindow preferences;
+
+    /** The current inspector window, or null if not yet opened. */
+    private InspectorWindow inspector;
+
+    public MenuActions(MainOverlay ol) {
+        overlay = ol;
         newFile();
     }
 
@@ -54,18 +67,22 @@ public class MenuActions {
         List<MenuItem> list = new ArrayList<>();
 
         MenuItem menuNew = new MenuItem("New");
+        menuNew.setAccelerator(new KeyCodeCombination(KeyCode.N, KeyCombination.SHORTCUT_DOWN));
         menuNew.setOnAction(this::onNew);
         list.add(menuNew);
 
         MenuItem menuOpen = new MenuItem("Open...");
+        menuOpen.setAccelerator(new KeyCodeCombination(KeyCode.O, KeyCombination.SHORTCUT_DOWN));
         menuOpen.setOnAction(this::onOpen);
         list.add(menuOpen);
 
         MenuItem menuSave = new MenuItem("Save");
+        menuSave.setAccelerator(new KeyCodeCombination(KeyCode.S, KeyCombination.SHORTCUT_DOWN));
         menuSave.setOnAction(this::onSave);
         list.add(menuSave);
 
         MenuItem menuSaveAs = new MenuItem("Save as...");
+        menuSaveAs.setAccelerator(new KeyCodeCombination(KeyCode.S, KeyCombination.SHIFT_DOWN, KeyCombination.SHORTCUT_DOWN));
         menuSaveAs.setOnAction(this::onSaveAs);
         list.add(menuSaveAs);
 
@@ -74,12 +91,20 @@ public class MenuActions {
 
     @SuppressWarnings("UnusedParameters")
     protected void showPreferences(ActionEvent actionEvent) {
-        this.overlay.showPreferences();
+        if (preferences == null) {
+            preferences = new PreferencesWindow(overlay);
+        }
+
+        preferences.show();
     }
 
     @SuppressWarnings("UnusedParameters")
     protected void showInspector(ActionEvent actionEvent) {
-        this.overlay.showInspector();
+        if (inspector == null) {
+            inspector = new InspectorWindow(overlay);
+        }
+
+        inspector.show();
     }
 
     protected void onNew(ActionEvent actionEvent) {
@@ -98,24 +123,24 @@ public class MenuActions {
      * @param actionEvent correspondign to the open request
      */
     protected void onOpen(ActionEvent actionEvent) {
-        Window window = this.overlay.getScene().getWindow();
+        Window window = overlay.getScene().getWindow();
         File file = new FileChooser().showOpenDialog(window);
 
         if (file != null) {
-            addChildrenFrom(file, this.overlay.getToplevelPane());
+            addChildrenFrom(file, overlay.getToplevelPane());
         }
     }
 
     protected void onSave(ActionEvent actionEvent) {
-        if (this.currentFile.isPresent()) {
-            saveTo(this.currentFile.get());
+        if (currentFile.isPresent()) {
+            saveTo(currentFile.get());
         } else {
             onSaveAs(actionEvent);
         }
     }
 
     protected void onSaveAs(ActionEvent actionEvent) {
-        Window window = this.overlay.getScene().getWindow();
+        Window window = overlay.getScene().getWindow();
         File file = new FileChooser().showSaveDialog(window);
 
         if (file != null) {
@@ -153,7 +178,7 @@ public class MenuActions {
             e.printStackTrace();
         }
     }
-    
+
     @SuppressWarnings("UnusedParameters")
     protected void toggleFullScreen(ActionEvent actionEvent) {
         Stage stage = Main.getStage();
@@ -168,5 +193,15 @@ public class MenuActions {
     @SuppressWarnings("UnusedParameters")
     protected void onQuit(ActionEvent actionEvent) {
         Platform.exit();
+    }
+
+    @SuppressWarnings("UnusedParameters")
+    protected void zoomIn(ActionEvent actionEvent) {
+        overlay.getToplevelPane().zoom(1.1);
+    }
+
+    @SuppressWarnings("UnusedParameters")
+    protected void zoomOut(ActionEvent actionEvent) {
+        overlay.getToplevelPane().zoom(1 / 1.1);
     }
 }

--- a/Code/src/main/java/nl/utwente/viskell/ui/ToplevelPane.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/ToplevelPane.java
@@ -319,4 +319,20 @@ public class ToplevelPane extends Region implements BlockContainer, Bundleable {
         // The toplevel is large enough to fit practical everything
     }
 
+    /**
+     * Zooms the underlying main pane in/out with a ratio, up to reasonable limits.
+     * @param ratio the additional zoom factor to apply.
+     */
+    protected void zoom(double ratio) {
+        double scale = getScaleX();
+
+        /* Limit zoom to reasonable range. */
+        if (scale <= 0.2 && ratio < 1) return;
+        if (scale >= 3 && ratio > 1) return;
+
+        setScaleX(scale * ratio);
+        setScaleY(scale * ratio);
+        setTranslateX(getTranslateX() * ratio);
+        setTranslateY(getTranslateY() * ratio);
+    }
 }

--- a/Code/src/test/java/nl/utwente/viskell/ui/MenuActionsTest.java
+++ b/Code/src/test/java/nl/utwente/viskell/ui/MenuActionsTest.java
@@ -1,0 +1,117 @@
+package nl.utwente.viskell.ui;
+
+import javafx.event.ActionEvent;
+import javafx.stage.Stage;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
+import java.io.File;
+import java.util.Optional;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
+
+/**
+ * Unit tests for MenuActions
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({MenuActions.class, Main.class, Stage.class, MainOverlay.class, PreferencesWindow.class, InspectorWindow.class})
+public class MenuActionsTest {
+    private MainOverlay mockMainOverlay;
+    private Stage mockStage;
+    private ActionEvent mockEvent;
+
+
+    @Before
+    public void Setup() throws Exception {
+        mockMainOverlay = mock(MainOverlay.class);
+        mockStage = mock(Stage.class);
+        mockStatic(Main.class);
+        when(Main.getStage()).thenReturn(mockStage);
+        mockEvent = mock(ActionEvent.class);
+    }
+
+    @Test
+    public void initialisesWithANewFileTest() {
+        // UUT
+        MenuActions menuActions = new MenuActions(mockMainOverlay);
+
+        // Access
+        Optional<File> currentFile = Whitebox.getInternalState(menuActions, "currentFile");
+
+        // verify
+        assertThat(currentFile.isPresent(), is(false));
+    }
+
+    @Test
+    public void showPreferencesTest() throws Exception {
+        // Mocks
+        PreferencesWindow mockPreferencesWindow = mock(PreferencesWindow.class);
+        whenNew(PreferencesWindow.class).withArguments(any()).thenReturn(mockPreferencesWindow);
+
+        // UUT
+        MenuActions menuActions = new MenuActions(mockMainOverlay);
+
+        // Test
+        menuActions.showPreferences(mockEvent);
+
+        // verify
+        verify(mockPreferencesWindow, times(1)).show();
+    }
+
+    @Test
+    public void showInspectorTest() throws Exception {
+        // Mocks
+        InspectorWindow mockInspectorWindow = mock(InspectorWindow.class);
+        whenNew(InspectorWindow.class).withArguments(any()).thenReturn(mockInspectorWindow);
+
+        // UUT
+        MenuActions menuActions = new MenuActions(mockMainOverlay);
+
+        // Test
+        menuActions.showInspector(mockEvent);
+
+        // verify
+        verify(mockInspectorWindow, times(1)).show();
+    }
+
+    @Test
+    public void zoomInTest() {
+        // mocks
+        ToplevelPane mockToplevelPane = mock(ToplevelPane.class);
+        when(mockMainOverlay.getToplevelPane()).thenReturn(mockToplevelPane);
+
+        // UUT
+        MenuActions menuActions = new MenuActions(mockMainOverlay);
+
+        // Test
+        menuActions.zoomIn(mockEvent);
+
+        // verify
+        verify(mockToplevelPane, times(1)).zoom(1.1);
+    }
+
+    @Test
+    public void zoomOutTest() {
+        // mocks
+        ToplevelPane mockToplevelPane = mock(ToplevelPane.class);
+        when(mockMainOverlay.getToplevelPane()).thenReturn(mockToplevelPane);
+
+        // UUT
+        MenuActions menuActions = new MenuActions(mockMainOverlay);
+
+        // Test
+        menuActions.zoomOut(mockEvent);
+
+        // verify
+        verify(mockToplevelPane, times(1)).zoom(1/1.1);
+    }
+}

--- a/Code/src/test/java/nl/utwente/viskell/ui/ToplevelPaneITCase.java
+++ b/Code/src/test/java/nl/utwente/viskell/ui/ToplevelPaneITCase.java
@@ -27,7 +27,7 @@ import static org.powermock.api.mockito.PowerMockito.whenNew;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Pane.class, Block.class})
-public class ToplevelPaneTest {
+public class ToplevelPaneITCase {
     private GhciSession mockGhci;
 
     @Before


### PR DESCRIPTION
Added Keyboard shortcuts for most menu items.
NOTE: There is a strange bug on Mac that Command & '-' to zoom out doesn't work on JavaFX.

Moved the zoom() method into ToplevelPane() which is the Pane it actually changes the view of and hence belongs to.

Moved the showPreferences() and showInspector() methods into MenuActions as they can be totally self-contained in there.

Added unit tests for some of the menu actions