### PR TITLE
Avoid encoding warning in verify output

### DIFF
--- a/Code/pom.xml
+++ b/Code/pom.xml
@@ -9,6 +9,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <junit.version>4.11</junit.version>
     <powermock.version>1.5.1</powermock.version>
     <skipTests>false</skipTests>


### PR DESCRIPTION
This pom addition avoids a warning in the output of “man verify” as the reporting plugins need a separate property for the encoding.