### PR TITLE
Skip tests that depend on Haskell binaries on the host machine.

### DIFF
--- a/Code/src/test/java/nl/utwente/viskell/ghcj/GhciEvaluatorTest.java
+++ b/Code/src/test/java/nl/utwente/viskell/ghcj/GhciEvaluatorTest.java
@@ -1,8 +1,11 @@
 package nl.utwente.viskell.ghcj;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Optional;
 
 public class GhciEvaluatorTest {
     /** Our connection with Ghci. */
@@ -11,9 +14,28 @@ public class GhciEvaluatorTest {
     /** A newline character. */
     private String NL = null;
 
+    /**
+     * Constructs GhciEvaluator, which, at the time of this writing, forks native processes
+     * and can fail with exceptions.
+     * <p><a href="https://github.com/viskell/viskell/issues/444">see issue #444</a></p>
+     * @return an optional GhciEvaluator
+     */
+    private static Optional<GhciEvaluator> getGhciEvaluator() {
+        GhciEvaluator evaluator = null;
+        try {
+            evaluator = new GhciEvaluator();
+        } catch (Exception e) {
+            // HaskellException expected when haskell executables are
+            // not found installed on the host.
+        }
+        return Optional.ofNullable(evaluator);
+    }
+
     @Before
     public void startGhci() throws HaskellException {
-        this.ghci = new GhciEvaluator();
+        Optional<GhciEvaluator> oEvaluator = getGhciEvaluator();
+        Assume.assumeTrue("https://github.com/viskell/viskell/issues/444", oEvaluator.isPresent());
+        this.ghci = oEvaluator.get();
         this.NL = System.getProperty("line.separator");
     }
 

--- a/Code/src/test/java/nl/utwente/viskell/ghcj/GhciSessionTest.java
+++ b/Code/src/test/java/nl/utwente/viskell/ghcj/GhciSessionTest.java
@@ -4,10 +4,7 @@ import nl.utwente.viskell.haskell.env.Environment;
 import nl.utwente.viskell.haskell.expr.Expression;
 import nl.utwente.viskell.haskell.expr.Value;
 import nl.utwente.viskell.haskell.type.Type;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 
 public class GhciSessionTest {
     /** Our session with Ghci. */
@@ -17,20 +14,26 @@ public class GhciSessionTest {
     private Expression pi;
 
     @Before
-    public void setUp() throws HaskellException {
-        this.env = new Environment();
-        this.ghci = new GhciSession();
-        this.ghci.startAsync();
-        this.ghci.awaitRunning();
-
-        this.env.addTestSignature("my_pi", "Float");
-        this.pi = new Value(Type.con("Float"), "3.14");
+    public void setUp() {
+        Exception setUpIssue = null;
+        try {
+            this.env = new Environment();
+            this.ghci = new GhciSession();
+            this.ghci.startAsync();
+            this.ghci.awaitRunning();
+            this.env.addTestSignature("my_pi", "Float");
+            this.pi = new Value(Type.con("Float"), "3.14");
+        } catch (Exception e) {
+            setUpIssue = e;
+        }
+        Assume.assumeNoException("could not set up GhciSession: "+setUpIssue.getMessage(), setUpIssue);
     }
 
     @After
     public void tearDown() {
         this.ghci.stopAsync();
-        this.ghci.awaitTerminated();
+        if (ghci.isRunning())
+            this.ghci.awaitTerminated();
     }
 
     @Test

--- a/Code/src/test/java/nl/utwente/viskell/ghcj/GhciSessionTest.java
+++ b/Code/src/test/java/nl/utwente/viskell/ghcj/GhciSessionTest.java
@@ -26,7 +26,8 @@ public class GhciSessionTest {
         } catch (Exception e) {
             setUpIssue = e;
         }
-        Assume.assumeNoException("could not set up GhciSession: "+setUpIssue.getMessage(), setUpIssue);
+        Assume.assumeNoException(setUpIssue == null ? "" :
+            "could not set up GhciSession: "+setUpIssue.getMessage(), setUpIssue);
     }
 
     @After


### PR DESCRIPTION
I limited my edits to just the test classes, but also filed the bug #444 earlier.

Ideally, the test for whether Haskell is installed would NOT involve an attempt to fork a processes, which it currently does. But changing that would require deeper refactoring. I'm happy to do that, but I'd like your feedback first. And I haven't even run Viskell yet; I'm just getting past the tests.